### PR TITLE
Small change: Fix broken link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ About
 =====
 
 Pipeworld is a zooming dataflow tool and desktop heavily inspired by
-[userland](https://www.userland.org). It is built using the [arcan desktop
+[userland](https://hisham.hm/userland/). It is built using the [arcan desktop
 engine](https://arcan-fe.com) [git](https://github.com/letoram/arcan).
 
 It combines the programmable processing of shell scripts and pipes, the


### PR DESCRIPTION
The userland example was moved to a new domain and the old one was a redirect link until 2024. Now domain is dead so it should be changed in a readme.